### PR TITLE
ci: mark PHP 8.5/Valgrind job experimental

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,12 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
-          - '8.5'
+        experimental:
+          - false
+        include:
+          - php: '8.5'
+            experimental: true
+
     name: "Build and Test (PHP ${{ matrix.php }}, with Valgrind)"
     runs-on: ubuntu-latest
     steps:
@@ -81,3 +86,4 @@ jobs:
         run: make test
         env:
           TEST_PHP_ARGS: "-m --show-diff --show-out --show-mem -d pcre.jit=0"
+        continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for CI testing, specifically around the PHP version matrix and experimental builds. The main focus is to improve how experimental PHP versions are handled in the CI pipeline.

**Workflow configuration improvements:**

* Added an `experimental` flag to the PHP version matrix and enabled `continue-on-error` for jobs marked as experimental, allowing failures in these jobs without failing the entire workflow.
* Moved PHP 8.5 to an experimental build by including it separately in the matrix with the `experimental: true` flag, instead of listing it with the stable versions.